### PR TITLE
Add support for alternate package names

### DIFF
--- a/pkg-install
+++ b/pkg-install
@@ -13,6 +13,7 @@ error() {
 
 #$1 is a quotation-marked, space-seperated list of package names.
 #$2 is the path to the program folder being installed.
+#"package0 package1 | package2" represents "package0 & package1" or "package0 & package2" (whichever is available) in $2
 #Example usage: ~/pi-apps/pkg-install "gparted buffer expect" ~/pi-apps/apps/Arduino
 
 PKG_LIST="$1" #quotation-marked, space-seperated list of package names to install
@@ -144,7 +145,7 @@ Version: 1.0
 Architecture: all
 Priority: optional
 Section: custom
-Depends: $(echo "$PKG_LIST" | tr -d ',' | sed 's/ /, /g')
+Depends: $(echo "$PKG_LIST" | tr -d ',' | sed 's/ /, /g' | sed  's/, |/ |/g' | sed 's/|, /| /g')
 Package: pi-apps-$appnamehash" > ~/pi-apps-$appnamehash/DEBIAN/control
 
 dpkg-deb --build ~/pi-apps-$appnamehash || error "pkg-install: failed to create dummy deb pi-apps-$appnamehash"


### PR DESCRIPTION
Add support for alternate package names if primary package name is not available in repos.

<b>Box86 install-64</b> currently looks like 
 
```
#install box86 dependencies
CODENAME="$(lsb_release -cs)"
if [[ "${CODENAME}" == "focal" || "${CODENAME}" == "buster" ]]; then
"${DIRECTORY}/pkg-install" "libraspberrypi0:armhf libssh-gcrypt-4:armhf libgssapi-krb5-2:armhf libkrb5-3:armhf libssl1.1:armhf libcups2:armhf libsdl1.2debian:armhf libopusfile0:armhf libc6:armhf libx11-6:armhf libgdk-pixbuf2.0-0:armhf libgtk2.0-0:armhf libstdc++6:armhf libsdl2-2.0-0:armhf mesa-va-drivers:armhf libsdl1.2-dev:armhf libsdl-mixer1.2:armhf libpng16-16:armhf libcal3d12v5:armhf libsdl2-net-2.0-0:armhf libopenal1:armhf libsdl2-image-2.0-0:armhf libvorbis-dev:armhf libcurl4:armhf osspd:armhf pulseaudio:armhf libjpeg62:armhf libudev1:armhf libgl1-mesa-dev:armhf libsnappy1v5:armhf libx11-dev:armhf libsmpeg0:armhf libboost-filesystem1.67.0:armhf libboost-program-options1.67.0:armhf libavcodec58:armhf libavformat58:armhf libswscale5:armhf libmyguiengine3debian1v5:armhf libboost-iostreams1.67.0:armhf  libsdl2-mixer-2.0-0:armhf" "$(dirname "$0")" || exit 1
elif [[ "${CODENAME}" == "groovy" || "${CODENAME} == "hirsute" ]]; then
"${DIRECTORY}/pkg-install" "libraspberrypi0:armhf libssh-gcrypt-4:armhf libgssapi-krb5-2:armhf libkrb5-3:armhf libssl1.1:armhf libcups2:armhf libsdl1.2debian:armhf libopusfile0:armhf libc6:armhf libx11-6:armhf libgdk-pixbuf2.0-0:armhf libgtk2.0-0:armhf libstdc++6:armhf libsdl2-2.0-0:armhf mesa-va-drivers:armhf libsdl1.2-dev:armhf libsdl-mixer1.2:armhf libpng16-16:armhf libcal3d12v5:armhf libsdl2-net-2.0-0:armhf libopenal1:armhf libsdl2-image-2.0-0:armhf libvorbis-dev:armhf libcurl4:armhf osspd:armhf pulseaudio:armhf libjpeg62:armhf libudev1:armhf libgl1-mesa-dev:armhf libsnappy1v5:armhf libx11-dev:armhf libsmpeg0:armhf libboost-filesystem1.71.0:armhf libboost-program-options1.71.0:armhf libavcodec58:armhf libavformat58:armhf libswscale5:armhf libmyguiengine3debian1v5:armhf libboost-iostreams1.71.0:armhf  libsdl2-mixer-2.0-0:armhf" "$(dirname "$0")" || exit 1
```

Afterwards it can be reduced to look like

```
#install box86 dependencies
"${DIRECTORY}/pkg-install" "libraspberrypi0:armhf libssh-gcrypt-4:armhf libgssapi-krb5-2:armhf libkrb5-3:armhf libssl1.1:armhf libcups2:armhf libsdl1.2debian:armhf libopusfile0:armhf libc6:armhf libx11-6:armhf libgdk-pixbuf2.0-0:armhf libgtk2.0-0:armhf libstdc++6:armhf libsdl2-2.0-0:armhf mesa-va-drivers:armhf libsdl1.2-dev:armhf libsdl-mixer1.2:armhf libpng16-16:armhf libcal3d12v5:armhf libsdl2-net-2.0-0:armhf libopenal1:armhf libsdl2-image-2.0-0:armhf libvorbis-dev:armhf libcurl4:armhf osspd:armhf pulseaudio:armhf libjpeg62:armhf libudev1:armhf libgl1-mesa-dev:armhf libsnappy1v5:armhf libx11-dev:armhf libsmpeg0:armhf libboost-filesystem1.67.0:armhf | libboost-filesystem1.71.0:armhf libboost-program-options1.67.0:armhf | libboost-program-options1.71.0:armhf libavcodec58:armhf libavformat58:armhf libswscale5:armhf libmyguiengine3debian1v5:armhf libboost-iostreams1.67.0:armhf | libboost-iostreams1.71.0:armhf  libsdl2-mixer-2.0-0:armhf" "$(dirname "$0")" || exit 1
```

So that apt will automatically choose which package to install among the alternatives separated with <b> " | " </b>

This is required as it can be used to reduce scripts as some packages have different names in Debian(Raspbian) and Ubuntu and one among them I recently came across is libturbojpeg [in Debian](https://packages.debian.org/search?keywords=libturbojpeg) and [in Ubuntu](https://packages.ubuntu.com/search?keywords=libturbojpeg) 

Also some packages have different names different distros as in the above example